### PR TITLE
Update `avdmanger` path - under latest Android SDK Command-line Tools

### DIFF
--- a/lib/fastlane/plugin/android_emulator/actions/android_emulator_action.rb
+++ b/lib/fastlane/plugin/android_emulator/actions/android_emulator_action.rb
@@ -14,10 +14,12 @@ module Fastlane
         system("#{adb} emu kill > /dev/null 2>&1 &")
         sleep(2)
 
+        cmd_avdmanager_create_avd="#{cmdline_tools_latest}/avdmanager create avd -n '#{params[:name]}' -f -k '#{params[:package]}' -d '#{params[:device]}'"
+        
         UI.message("Creating new emulator")
-        UI.message("Calling #{cmdline_tools_latest}/avdmanager create avd")
+        UI.message(cmd_avdmanager_create_avd)
         FastlaneCore::CommandExecutor.execute(
-          command: "#{cmdline_tools_latest}/avdmanager create avd -n '#{params[:name]}' -f -k '#{params[:package]}' -d '#{params[:device]}'",
+          command: cmd_avdmanager_create_avd,
           print_all: true,
           print_command: false
         )

--- a/lib/fastlane/plugin/android_emulator/actions/android_emulator_action.rb
+++ b/lib/fastlane/plugin/android_emulator/actions/android_emulator_action.rb
@@ -8,14 +8,16 @@ module Fastlane
         sdk_dir = params[:sdk_dir]
         port = params[:port]
         adb = "#{sdk_dir}/platform-tools/adb"
+        cmdline_tools_latest="#{sdk_dir}/cmdline-tools/latest/bin"
 
         UI.message("Stopping emulator")
         system("#{adb} emu kill > /dev/null 2>&1 &")
         sleep(2)
 
         UI.message("Creating new emulator")
+        UI.message("Calling #{cmdline_tools_latest}/avdmanager create avd")
         FastlaneCore::CommandExecutor.execute(
-          command: "#{sdk_dir}/tools/bin/avdmanager create avd -n '#{params[:name]}' -f -k '#{params[:package]}' -d '#{params[:device]}'",
+          command: "#{cmdline_tools_latest}/avdmanager create avd -n '#{params[:name]}' -f -k '#{params[:package]}' -d '#{params[:device]}'",
           print_all: true,
           print_command: false
         )


### PR DESCRIPTION
The latest Android SDK Command-line Tools has been relocated to `cmdline-tools/latest/`. Hence the path of `avdmanager` has been changed to `cmdline-tools/latest/bin/avdmanager`.

<img width="1106" alt="Screen Shot 2022-05-03 at 1 06 43 PM" src="https://user-images.githubusercontent.com/7858565/166390846-315b903b-3fe3-4195-912e-5b3e018a06a9.png">

Here is the error encountered before updating the path in the script. `avdmanager` was called when **creating new emulator**.

```
[11:18:43]: ----------------------------------------------------------------
[11:18:43]: --- Step: Switch to android update_meta_teninch_screens lane ---
[11:18:43]: ----------------------------------------------------------------
[11:18:43]: Cruising over to lane 'android update_meta_teninch_screens' 🚖
[11:18:43]: ------------------------------
[11:18:43]: --- Step: android_emulator ---
[11:18:43]: ------------------------------
[11:18:43]: Stopping emulator
[11:18:45]: Creating new emulator
[11:18:45]: ▸ Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
[11:18:45]: ▸   at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
[11:18:45]: ▸   at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
[11:18:45]: ▸   at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
[11:18:45]: ▸   at com.android.sdklib.tool.AvdManagerCli.run(AvdManagerCli.java:213)
[11:18:45]: ▸   at com.android.sdklib.tool.AvdManagerCli.main(AvdManagerCli.java:200)
[11:18:45]: ▸ Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
[11:18:45]: ▸   at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
[11:18:45]: ▸   at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
[11:18:45]: ▸   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
[11:18:45]: ▸   ... 5 more
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
        at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
        at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
        at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
        at com.android.sdklib.tool.AvdManagerCli.run(AvdManagerCli.java:213)
        at com.android.sdklib.tool.AvdManagerCli.main(AvdManagerCli.java:200)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 5 more
[11:18:45]: Exit status: 1
```

Reference: https://stackoverflow.com/a/64389804